### PR TITLE
Fix forced language translit for multilang string

### DIFF
--- a/lib/translit.rb
+++ b/lib/translit.rb
@@ -2,9 +2,11 @@
 
 module Translit
   def self.convert(text, enforce_language = nil)
-    language = detect_input_language(text.split(/\s+/).first)
-
-    return text if language == enforce_language
+    language = if enforce_language
+      enforce_input_language(enforce_language)
+    else
+      detect_input_language(text.split(/\s+/).first)
+    end
 
     map = self.send(language.to_s).sort_by {|k,v| v.length <=>  k.length}
     map.each do |translit_key, translit_value|
@@ -27,6 +29,14 @@ private
 
   def self.detect_input_language(text)
     text.scan(/\w+/).empty? ? :russian : :english
+  end
+
+  def self.enforce_input_language(language)
+    if language == :english
+      :russian
+    else
+      :english
+    end
   end
 
   def self.english

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -17,4 +17,7 @@ end
 context "Translit#convert with enforced language" do
   should("transliterate to that language") { Translit.convert("test", :english)}.equals("test")
   should("keep it the same if language matched the text") {Translit.convert("test", :russian)}.equals("тест")
+
+  should("transliterate to english language if input language is mixed") { Translit.convert("test тест", :english)}.equals("test test")
+  should("transliterate to russian language if input language is mixed") { Translit.convert("test тест", :russian)}.equals("тест тест")
 end


### PR DESCRIPTION
Hi!
I found a problem in translit logic. 
Example:

``` ruby
Translit.convert('test тест', :english)
=> "test тест"
Translit.convert('test тест', :russian)
=> "тест тест"
```

And I try to fix this problem by this pull request =)
